### PR TITLE
Fix loading weapons 9-13

### DIFF
--- a/profile.cpp
+++ b/profile.cpp
@@ -57,7 +57,7 @@ FILE *fp;
 	{
 		int type = fgetl(fp);
 		if (!type) break;
-        if (type < 0 || type >= MAX_WPN_SLOTS) {
+        if (type < 0 || type >= WPN_COUNT) {
             staterr("profile_load: invalid weapon type %d", type);
             break;
         }


### PR DESCRIPTION
The new check to prevent crashes during profile loading only allowed weapons up to MAX_WPN_SLOTS (8). There are weapons with an index of higher than 8 in the game.