### PR TITLE
Fix crash in LoadFXCache

### DIFF
--- a/common/misc.fdh
+++ b/common/misc.fdh
@@ -18,7 +18,9 @@ void staterr(const char *fmt, ...);
 
 //------------------[referenced from common/misc.cpp]----------------//
 uint16_t fgeti(FILE *fp);
+uint16_t fgeti(FILE *fp, int *eof);
 uint32_t fgetl(FILE *fp);
+uint32_t fgetl(FILE *fp, int *eof);
 void fputi(uint16_t word, FILE *fp);
 void fputl(uint32_t word, FILE *fp);
 uint16_t fgeti(FILE *fp);

--- a/sound/pxt.cpp
+++ b/sound/pxt.cpp
@@ -943,13 +943,14 @@ stPXSound snd;
 	
 	int allocd_size = 0;
 	snd.final_buffer = NULL;
+	int eof = 0;
 	
 	stat("LoadFXCache: restoring pxts from cache");
 	for(;;)
 	{
-		snd.final_size = fgetl(fp);
+		snd.final_size = fgetl(fp, &eof);
+		if (eof) break;
 		slot = fgetc(fp);
-		if (slot == -1) break;
 		
 		if (snd.final_size > allocd_size)
 		{

--- a/sound/pxt.fdh
+++ b/sound/pxt.fdh
@@ -70,6 +70,7 @@ int random(int min, int max);
 void fputl(unsigned int word, FILE *fp);
 void fputi(unsigned short word, FILE *fp);
 unsigned int fgetl(FILE *fp);
+unsigned int fgetl(FILE *fp, int *eof);
 unsigned short fgeti(FILE *fp);
 int fgeticsv(FILE *fp);
 double fgetfcsv(FILE *fp);


### PR DESCRIPTION
LoadFXCache scans the file until if hits in EOF, so it requires a way of knowing when the end of the file is reached. Previously, loading the sound effects cache would always crash the program. The new fgeti and fgetl variants provide a way for callers to handle EOF manually instead of aborting the program.

As a sidenote, I'm not sure that the [relatively new behavior](https://github.com/EXL/NXEngine/pull/9) aborting on any EOF is desirable, but if that's what we're going to do, we at least need a way of detecting EOF without causing the program to exit.

Also, I'm not sure where to get a copy of Caitlin Shaw's Makegen program, so I just manually added function declarations to the fdh files.