### PR TITLE
Make presses able to fall more than once

### DIFF
--- a/ai/sym/sym.cpp
+++ b/ai/sym/sym.cpp
@@ -711,7 +711,7 @@ void ai_press(Object *o)
 				SmokeSide(o, 4, DOWN);
 				quake(10);
 				
-				o->state = 11;
+				o->state = 0;
 				o->frame = 0;
 				o->damage = 0;
 				o->flags |= FLAG_SOLID_BRICK;


### PR DESCRIPTION
Previously, after a press fell the first time it would stop forever. If you broke the block under it, it would stay floating in midair. Now it resets to the waiting state after hitting the ground.

See https://github.com/nxengine/nxengine-evo/pull/236